### PR TITLE
Fixed copy constructor not setting the proper capacity

### DIFF
--- a/include/digestible/digestible.h
+++ b/include/digestible/digestible.h
@@ -276,7 +276,11 @@ tdigest<Values, Weight>::tdigest(const tdigest<Values, Weight>& other)
     , min_val(other.min_val)
     , max_val(other.max_val)
     , run_forward(other.run_forward)
-{}
+{
+    one.values.reserve(other.one.capacity());
+    two.values.reserve(other.two.capacity());
+    buffer.values.reserve(other.buffer.capacity() * buffer_multiplier);
+}
 
 template <typename Values, typename Weight>
 void tdigest<Values, Weight>::swap(tdigest<Values, Weight>& other)


### PR DESCRIPTION
Currently the copy constructor doesn't reserve the proper amount for the value vector since the copy constructor of the std::vector only reserves space for the current length of the vector.

This results in new values inserted being instantly merged causing completely wrong bins.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/SpirentOrion/digestible/10)
<!-- Reviewable:end -->
